### PR TITLE
use Int instead of Int64 in sparse matrix type

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -19,7 +19,7 @@ mutable struct PavitoNonlinearModel <: MathProgBase.AbstractNonlinearModel
     numvar::Int
     numconstr::Int
     numnlconstr::Int
-    A::SparseMatrixCSC{Float64,Int64}
+    A::SparseMatrixCSC{Float64,Int}
     A_lb::Vector{Float64}
     A_ub::Vector{Float64}
     lb::Vector{Float64}


### PR DESCRIPTION
possibly related to Appveyor failure on 1.0 x86; see #14 