### PR TITLE
FIX: Bugs in algorithm, missing solver metadata

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -278,3 +278,23 @@ function MOI.get(model::Optimizer, ::MOI.VariablePrimal, v::MOI.VariableIndex)
 end
 MOI.get(model::Optimizer, ::MOI.ObjectiveValue) = model.objective_value
 MOI.get(model::Optimizer, ::MOI.ObjectiveBound) = model.objective_bound
+
+function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
+    if MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+        return MOI.FEASIBLE_POINT
+    else
+        return MOI.NO_SOLUTION
+    end
+end
+
+function MOI.get(::Optimizer, ::MOI.DualStatus)
+    return MOI.NO_SOLUTION
+end
+
+function MOI.get(model::Optimizer, ::MOI.ResultCount)
+    return MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT ? 1 : 0
+end
+
+function MOI.get(::Optimizer, ::MOI.SolverName)
+    return "Pavito"
+end

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -293,12 +293,8 @@ function fix_int_vars(optimizer::MOI.ModelLike, vars, mip_solution, int_indices)
         if MOI.is_valid(optimizer, ci)
             MOI.set(optimizer, MOI.ConstraintSet(), ci, set)
         else
-            ci = MOI.ConstraintIndex{MOI.SingleVariable, MOI.ZeroOne}(idx)
-
-            if MOI.is_valid(optimizer, ci)
-                func = MOI.SingleVariable(vi)
-                MOI.add_constraint(optimizer, func, set)
-            end
+            func = MOI.SingleVariable(vi)
+            MOI.add_constraint(optimizer, func, set)
         end
     end
 end

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -7,7 +7,7 @@
 eval_func(values, func) = MOI.Utilities.eval_variables(vi -> values[vi.value], func)
 
 function eval_objective(model::Optimizer, values)
-    if model.nlp_block != nothing && model.nlp_block.has_objective
+    if model.nlp_block !== nothing && model.nlp_block.has_objective
         return MOI.eval_objective(model.nlp_block.evaluator, values)
     else
         return eval_func(values, model.objective)

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -5,13 +5,15 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 eval_func(values, func) = MOI.Utilities.eval_variables(vi -> values[vi.value], func)
+
 function eval_objective(model::Optimizer, values)
-    return if model.nlp_block.has_objective
-        MOI.eval_objective(model.nlp_block.evaluator, values)
+    if model.nlp_block != nothing && model.nlp_block.has_objective
+        return MOI.eval_objective(model.nlp_block.evaluator, values)
     else
-        eval_func(values, model.objective)
+        return eval_func(values, model.objective)
     end
 end
+
 function eval_gradient(func::SQF, grad_f, values)
     fill!(grad_f, 0.0)
     for term in func.affine_terms
@@ -101,7 +103,10 @@ function MOI.optimize!(model::Optimizer)
 
     if MOI.supports(model.mip_optimizer, MOI.VariablePrimalStart(), MOI.VariableIndex) && all(isfinite, model.incumbent)
         MOI.set(model.mip_optimizer, MOI.VariablePrimalStart(), model.mip_variables, model.incumbent)
-        MOI.set(model.mip_optimizer, MOI.VariablePrimalStart(), model.θ, eval_objective(model, model.incumbent))
+
+        if model.θ !== nothing
+            MOI.set(model.mip_optimizer, MOI.VariablePrimalStart(), model.θ, eval_objective(model, model.incumbent))
+        end
     end
 
 
@@ -143,10 +148,16 @@ function MOI.optimize!(model::Optimizer)
         function heuristic_callback(cb)
             # if have a new best feasible solution since last heuristic solution added, set MIP solution to the new best feasible solution
             if model.new_incumb
-                MOI.submit(model.mip_optimizer, MOI.HeuristicSolution(cb), [model.mip_variables; model.θ], [model.incumbent; model.objective_value])
+                if model.θ === nothing
+                    MOI.submit(model.mip_optimizer, MOI.HeuristicSolution(cb), model.mip_variables, model.incumbent)
+                else
+                    MOI.submit(model.mip_optimizer, MOI.HeuristicSolution(cb), [model.mip_variables; model.θ], [model.incumbent; model.objective_value])
+                end
+
                 model.new_incumb = false
             end
         end
+
         MOI.set(model.mip_optimizer, MOI.HeuristicCallback(), heuristic_callback)
 
         if isfinite(model.timeout)
@@ -278,11 +289,16 @@ function fix_int_vars(optimizer::MOI.ModelLike, vars, mip_solution, int_indices)
         MOI.is_valid(optimizer, ci) && MOI.delete(optimizer, ci)
         ci = MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}(idx)
         set = MOI.EqualTo(mip_solution[i])
+
         if MOI.is_valid(optimizer, ci)
             MOI.set(optimizer, MOI.ConstraintSet(), ci, set)
         else
-            func = MOI.SingleVariable(vi)
-            MOI.add_constraint(optimizer, func, set)
+            ci = MOI.ConstraintIndex{MOI.SingleVariable, MOI.ZeroOne}(idx)
+
+            if MOI.is_valid(optimizer, ci)
+                func = MOI.SingleVariable(vi)
+                MOI.add_constraint(optimizer, func, set)
+            end
         end
     end
 end


### PR DESCRIPTION
This addresses some issues I was encountering while testing the new version. Not sure if there's a more accurate way to set `PrimalStatus` and `ResultCount`.